### PR TITLE
Change for..of to es5 loop

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -600,7 +600,9 @@ var MiniProfiler = (function () {
             return new Promise(function(resolve,reject) {
               __originalFetch(input,init).then(function(response) {
                 // look for x-mini-profile-ids
-                for (var pair of response.headers.entries()) {
+                var entries = response.headers.entries();
+                for (var i = 0; i < entries.length; i++) {
+                  var pair = entries[i];
                   if(pair[0] && (pair[0].toLowerCase() == 'x-miniprofiler-ids')) {
                   var ids = JSON.parse(pair[1]);
                     fetchResults(ids);


### PR DESCRIPTION
The `for..of` loop is not supported in IE11, so this breaks in development. This commit changes that loop to an ES5-style iterator.